### PR TITLE
add caching/throttling of respones

### DIFF
--- a/lib/mdns-server.js
+++ b/lib/mdns-server.js
@@ -3,7 +3,7 @@
 const multicastdns = require('multicast-dns');
 const dnsEqual = require('dns-equal');
 const flatten = require('array-flatten');
-const deepEqual = require('deep-equal');
+var _isEqual = require('lodash').isEqual;
 
 module.exports = Server;
 
@@ -12,6 +12,9 @@ function Server(opts) {
 	this.mdns.setMaxListeners(0);
 	this.registry = {};
 	this.mdns.on('query', this._respondToQuery.bind(this))
+	this.recentResponses = [];
+	this.clearCacheTime = 60000;
+	this.timer = null;
 }
 
 Server.prototype.register = function (records) {
@@ -43,50 +46,82 @@ Server.prototype.unregister = function (records) {
 	}
 };
 
-Server.prototype._respondToQuery = function (query) {
-	const self = this;
-	query.questions.forEach(function (question) {
-		const type = question.type;
-		const name = question.name;
+Server.prototype._clearTimer = function () {
+	//console.log('clearing cache');
+	//console.log(this.recentResponses);
+	this.recentResponses.splice(0,this.recentResponses.length)
+	clearTimeout(this.timer);
+	this.timer = null;
+};
+Server.prototype._respondToQuery = function(query) {
+    var self = this;
+    if (self.timer == null)
+        self.timer = setTimeout(self._clearTimer.bind(self), self.clearCacheTime);
 
-		// generate the answers section
-		const answers = type === 'ANY'
-			? flatten.depth(Object.keys(self.registry).map(self._recordsFor.bind(self, name)), 1)
-			: self._recordsFor(name, type);
+    query.questions.forEach(function(question) {
 
-		if (answers.length === 0) return;
+        const type = question.type;
+        const name = question.name;
 
-		// generate the additionals section
-		let additionals = [];
-		if (type !== 'ANY') {
-			answers.forEach(function (answer) {
-				if (answer.type !== 'PTR') return;
-				additionals = additionals
-					.concat(self._recordsFor(answer.data, 'SRV'))
-					.concat(self._recordsFor(answer.data, 'TXT'))
-			});
+        // generate the answers section
+        const answers = type === 'ANY' ?
+            flatten.depth(Object.keys(self.registry).map(self._recordsFor.bind(self, name)), 1) :
+            self._recordsFor(name, type);
 
-			// to populate the A and AAAA records, we need to get a set of unique
-			// targets from the SRV record
-			additionals
-				.filter(function (record) {
-					return record.type === 'SRV'
-				})
-				.map(function (record) {
-					return record.data.target
-				})
-				.filter(unique())
-				.forEach(function (target) {
-					additionals = additionals
-						.concat(self._recordsFor(target, 'A'))
-						.concat(self._recordsFor(target, 'AAAA'))
-				})
-		}
+        if (answers.length === 0) return;
 
-		self.mdns.respond({answers: answers, additionals: additionals}, function (err) {
-			if (err) throw err // TODO: Handle this (if no callback is given, the error will be ignored)
-		})
-	})
+        // generate the additionals section
+        let additionals = [];
+        if (type !== 'ANY') {
+            answers.forEach(function(answer) {
+                if (answer.type !== 'PTR') return;
+                additionals = additionals
+                    .concat(self._recordsFor(answer.data, 'SRV'))
+                    .concat(self._recordsFor(answer.data, 'TXT'))
+            });
+
+            // to populate the A and AAAA records, we need to get a set of unique
+            // targets from the SRV record
+            additionals
+                .filter(function(record) {
+                    return record.type === 'SRV'
+                })
+                .map(function(record) {
+                    return record.data.target
+                })
+                .filter(unique())
+                .forEach(function(target) {
+                    additionals = additionals
+                        .concat(self._recordsFor(target, 'A'))
+                        .concat(self._recordsFor(target, 'AAAA'))
+                })
+        }
+        let currentResponse = {
+            answers: answers,
+            additionals: additionals
+        };
+
+        let foundRecentResponse = false;
+
+        for (let recentResponseCtr = 0; recentResponseCtr < self.recentResponses.length; recentResponseCtr++) {
+            if (_isEqual(self.recentResponses[recentResponseCtr], currentResponse)) {
+                foundRecentResponse = true;
+                //console.log('found recent response!!!!')
+                break;
+            }
+        }
+
+        if (!foundRecentResponse) {
+            self.recentResponses.push(Object.assign({}, currentResponse));
+            self.mdns.respond(currentResponse, function(err) {
+                if (err) throw err // TODO: Handle this (if no callback is given, the error will be ignored)
+            })
+
+        } else {
+            //console.log('**RECENTLY SENT SAME RESPONSE**')
+        }
+    })
+
 };
 
 Server.prototype._recordsFor = function (name, type) {

--- a/lib/mdns-server.js
+++ b/lib/mdns-server.js
@@ -13,7 +13,7 @@ function Server(opts) {
 	this.registry = {};
 	this.mdns.on('query', this._respondToQuery.bind(this))
 	this.recentResponses = [];
-	this.clearCacheTime = 60000;
+	this.clearCacheTime = 5000;
 	this.timer = null;
 }
 


### PR DESCRIPTION
Added support to throttle responses, if they are the same response that was recently sent. If a rogue actor creates a malicious mdns query storm, we will respond at a limited rate, which is currently set to approximately 1 minute.